### PR TITLE
Make systemd configuration match image

### DIFF
--- a/devicehive-dev/rm-monitorhook-log.sh
+++ b/devicehive-dev/rm-monitorhook-log.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+rm -f /home/pi/openears/devicehive-dev/monitorhook.log

--- a/serval/serval.service
+++ b/serval/serval.service
@@ -4,13 +4,13 @@ After=multi-user.target
 
 [Service]
 Type=idle
-ExecStart=/home/henk/Projecten/sound/serval/serval.sh
-ExecStop=rm -f /home/henk/Projecten/sound/DL/devicehive-dev/monitorhook.log
-User=henk
-Group=henk
+ExecStart=/bin/bash /home/pi/openears/serval/serval.sh
+ExecStop=/bin/bash /home/pi/openears/devicehive-dev/rm-monitorhook-log.sh
+User=pi
+Group=pi
 Restart=always
 RestartSec=5
-WorkingDirectory=/home/henk/Projecten/sound/DL/devicehive-dev
+WorkingDirectory=/home/pi/openears/devicehive-dev
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
In serval/serval.service (the configuration file for "systemctl ..."), pathes refer to a user 'henk' who is not present in the image file. Also the "from scratch" installation does not create this user. In this pull request, the file is modfied in order to match the actual user and directory structure as created by the image and by the from scratch installations.
Also ExecStart and ExecStop in serval.service are specified in a surefire way.